### PR TITLE
add execution environment file for ansible-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Contains Ansible playbooks for installing operators and checking status of the install.
 
 ## Usage
+
+### Setup
 Set the following env vars:
 
 ```
@@ -14,8 +16,38 @@ or if you prefer set:
 K8S_AUTH_KUBECONFIG=<path to your kubeconfig file>
 ```
 
-Copy var.yaml.example to vars.yaml and modify accordingly. If packages is empty, it will pull ALL packages
-from the catalog source.
+Copy `var.yaml.example` to `vars.yaml` and modify accordingly. If `packages` value is empty, it will pull ALL packages from the catalog source.
 
-`ansible-playbook -e @vars.yaml audits.yaml`
+### Run playbooks with Ansible Navigator
+
+The fastest way to get started is to run the playbooks via `ansible-navigator` with an Ansible execution environment container image:
+
+```
+ansible-navigator run audits.yaml --container-engine podman --eei quay.io/opdev/opcap-ansible-ee:latest -e @vars.yaml --penv K8S_AUTH_VERIFY_SSL --penv K8S_AUTH_API_KEY --penv K8S_AUTH_HOST -m stdout
+````
+
+or if you prefer to provide a kubeconfig:
+
+```
+ansible-navigator run audits.yaml --container-engine podman --eei quay.io/opdev/opcap-ansible-ee:latest -e @vars.yaml --senv K8S_AUTH_KUBECONFIG=/dir/kubeconfig --eev /dir:/dir -m stdout
+```
+
+### Run playbooks with Ansible Playbook
+
+
+You may prefer to run playbooks via `ansible-playbook` although this method requires proper dependencies installed on localhost:
+
+```
+ansible-playbook -e @vars.yaml audits.yaml
+```
+
+### Misc
+
+Build your own execution environment image with `ansible-builder`:
+
+```
+ansible-builder build  --container-runtime=podman --tag=opcap-ansible-ee --prune-images --verbosity 3
+```
+
+
 

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -1,0 +1,12 @@
+---
+version: 3
+
+build_arg_defaults:
+  ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: '--force --verbose'
+
+dependencies:
+  ansible_core:
+    package_pip: ansible-core==2.13.10
+  ansible_runner:
+    package_pip: ansible-runner==2.3.2
+  galaxy: requirements.yml

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: kubernetes.core


### PR DESCRIPTION
Adding execution environment file for building an ee container image via ansible-builder.

To build it: `ansible-builder build --container-runtime=podman --tag=opcap-ansible-ee --prune-images --verbosity 3`.

Due to `openshift-clients` package requirement when pulling in kubernetes.core collection within ansible-builder's multi-stage build, it will require a subscription-manager login on the host running the build. I tried a variety of combinations of aap base images + additional dependencies with no success. An elegant solution may still exist. See https://access.redhat.com/solutions/6985157 and https://github.com/ansible/ansible-builder/issues/472 for more info.

Use ansible-navigator to run playbooks: `ansible-navigator run audits.yaml --eei quay.io/opdev/opcap-ansible-ee:latest -e @vars.yaml --senv K8S_AUTH_KUBECONFIG=/dir/config --eev /dir:/dir -m stdout`

Issue #1 
