### PR TITLE
ADD fips-assessments for openshift serverless

### DIFF
--- a/fips_assessment.yml
+++ b/fips_assessment.yml
@@ -1,0 +1,18 @@
+---
+# Checkout fips-assessments repo for testing tasks
+- name: git checkout fips-assessment tests
+  ansible.builtin.git:
+    repo: https://github.com/opdev/fips-assessments.git
+    dest: /tmp/fips-assessments/
+
+# Include the path for each fips assessment test below
+# they should be found at https://github.com/opdev/fips-assessments/<operator>/tasks/
+# Make sure your tests have proper cleanup tasks
+- name: openshift serverless fips assessment
+  ansible.builtin.include_tasks: /tmp/fips-assessments/openshift-serverless/tasks/main.yml
+
+# Clean up task files
+- name: delete temporary files from fips-assessment
+  ansible.builtin.file:
+    path: /tmp/fips-assessments/
+    state: absent

--- a/install.yml
+++ b/install.yml
@@ -68,6 +68,9 @@
   until: result.resources[0] is defined and result.resources[0].status.phase == "Succeeded"
   retries: 10
   delay: 10
+- name: Run FIPS enabled tests
+  ansible.builtin.include_tasks: fips_assessment.yml
+  when: fips_assessment is defined and fips_assessment  
 - name: Clean up namespace
   kubernetes.core.k8s:
     api_version: v1

--- a/vars.yml.example
+++ b/vars.yml.example
@@ -9,3 +9,7 @@ detailedreports: false
 catalog_source: certified-operators
 catalog_source_namespace: openshift-marketplace
 cleanup: true
+# To run operator tests on FIPS enabled clusters
+#  1. list only packages that have corresponding tests on packages var
+#  2. uncomment and set fips_assessment to true below
+# fips_assessment: true


### PR DESCRIPTION
Adding fips_assessment.yml with tasks for assessing fips enabled clusters with openshift-serverless.

This PR will include: 
- one task file reference pointing to the fips-assessments repo
- some vars examples on how to enable the tests
- a few changes to gitignore preventing logs and artifacts to be uploaded to this repo

