### PR TITLE
Add reporting for operator installs

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,11 @@
+[defaults]
+# This should be enabled in a more automated system.
+# The "global_custom_stats" key will contain the output from the opcap run.
+# Otherwise, for development purposes, the regular stdout callback should
+# be used.
+# stdout_callback = ansible.posix.json
+
+# With this option set, you will still see the custom stats at the end of 
+# the run, so you can still validate what would be output.
+show_custom_stats = true
+

--- a/audits.yml
+++ b/audits.yml
@@ -3,19 +3,35 @@
   hosts: localhost
   gather_facts: false
   tasks:
+    - name: Only gather date_time to facts
+      ansible.builtin.setup:
+        filter:
+          - ansible_date_time
+    - name: Set current date to stats
+      ansible.builtin.set_stats:
+        data:
+          current_date: "{{ ansible_date_time.date }}"
     - name: Get K8S cluster info
       kubernetes.core.k8s_cluster_info:
       register: ocp_version
       no_log: true
     - name: Save cluster version
-      ansible.builtin.set_fact:
-        k8s_cluster_version: "{{ ocp_version.version.server.kubernetes }}"
+      ansible.builtin.set_stats:
+        data:
+          k8s_cluster_version: "{{ ocp_version.version.server.kubernetes }}"
     - name: Get OpenShift cluster info
       kubernetes.core.k8s_info:
         api_version: "config.openshift.io/v1"
         kind: ClusterVersion
         name: version
       register: openshift_cluster_version
+      failed_when: >
+        (openshift_cluster_version.resources[0] is not defined) or
+        (openshift_cluster_version.resources[0] == "")
+    - name: Save OpenShift cluster info
+      ansible.builtin.set_stats:
+        data:
+          openshift_cluster_version: "{{ openshift_cluster_version.resources[0].status.history[0].version }}"
     - name: Get PackageManifests
       kubernetes.core.k8s_info:
         api_version: "packages.operators.coreos.com/v1"
@@ -45,7 +61,7 @@
         repo: https://github.com/opdev/fips-assessments.git
         dest: "{{ fips_repo }}"
       when: fips_assessment | default(false)
-    - name: Execute operator_install.yml for each opernshift_sub_info
+    - name: Execute operator_install.yml for each openshift_sub_info
       ansible.builtin.include_tasks: operator_install.yml
       loop: "{{ openshift_sub_info }}"
       loop_control:

--- a/install.yml
+++ b/install.yml
@@ -58,19 +58,39 @@
   until: subscription.resources[0].status.currentCSV is defined
   retries: 10
   delay: 10
-- name: Get CSV Completed
-  kubernetes.core.k8s_info:
-    namespace: "{{ full_namespace }}"
-    name: "{{ subscription.resources[0].status.currentCSV }}"
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-  register: result
-  until: result.resources[0] is defined and result.resources[0].status.phase == "Succeeded"
-  retries: 10
-  delay: 10
+- name: Get CSV and report
+  block:
+    - name: Get CSV Completed
+      kubernetes.core.k8s_info:
+        namespace: "{{ full_namespace }}"
+        name: "{{ subscription.resources[0].status.currentCSV }}"
+        api_version: operators.coreos.com/v1alpha1
+        kind: ClusterServiceVersion
+      register: result
+      until: result.resources[0] is defined and result.resources[0].status.phase == "Succeeded"
+      retries: 30
+      delay: 10
+      failed_when: result.resources is not defined or result.resources | length == 0 or result.resources[0].status.phase != "Succeeded"
+  rescue:
+    - name: Set timeout
+      ansible.builtin.set_fact:
+        operator_timeout: true
 - name: Run FIPS enabled tests
   ansible.builtin.include_tasks: fips_assessment.yml
   when: fips_assessment | default(false)
+- name: Create stat
+  ansible.builtin.set_fact:
+    package:
+      name: "{{ manifest_data.packageName }}"
+      channel: "{{ channel.name }}"
+      install_mode: "{{ item }}"
+      result: "{{ (operator_timeout | default(false)) | ternary('timeout', result.resources[0].status.phase | default('')) }}"
+      message: "{{ result.resources[0].status.message | default('') }}"
+      reason: "{{ result.resources[0].status.reason | default('') }}"
+- name: Push stats
+  ansible.builtin.set_stats:
+    data:
+      operators: "{{ [package] }}"
 - name: Clean up namespace
   kubernetes.core.k8s:
     api_version: v1


### PR DESCRIPTION
This is a first attempt at reporting. While similar to the original opcap, the format is slightly different. Since the tools does not go against more than one cluster at a time, it reports the date, the OpenShift version, and Kubernetes version as "top-level" data, and each operator install (per install mode) will have an entry.

The output, when used with the JSON callback module, will be contained in the "global_custom_stats" key in the output, and will look like this:

```
{
...
    "global_custom_stats": {
        "current_date": "2023-07-18",
        "k8s_cluster_version": {
            "buildDate": "2023-07-04T08:59:21Z",
            "compiler": "gc",
            "gitCommit": "0c8cb213485c84deb0230cbefa34bf7f1c311418",
            "gitTreeState": "clean",
            "gitVersion": "v1.25.11+1485cc9",
            "goVersion": "go1.19.10 X:strictfipsruntime",
            "major": "1",
            "minor": "25",
            "platform": "linux/amd64"
        },
        "openshift_cluster_version": "4.12.24",
        "operators": [
            {
                "channel": "stable",
                "install_mode": "OwnNamespace",
                "message": "installing: waiting for deployment cass-operator-controller-manager to become ready: deployment \"cass-operator-controller-manager\" not available: Deployment does not have minimum availability.",
                "name": "cass-operator",
                "reason": "InstallWaiting",
                "result": "timeout"
            },
            {
                "channel": "stable",
                "install_mode": "SingleNamespace",
                "message": "install strategy completed with no errors",
                "name": "cass-operator",
                "reason": "InstallSucceeded",
                "result": "Succeeded"
            }
        ]
    },
...
}
```

Obviously, jq can be used to process this.

Fixes #2 