### PR TITLE
Add 'target_namespace' as a variable to call to fips assessments

### DIFF
--- a/audits.yml
+++ b/audits.yml
@@ -58,8 +58,10 @@
         fips_repo: "{{ fips_repo_base_path | default('/tmp') }}/fips-assessments/"
     - name: Git checkout fips-assessment tests
       ansible.builtin.git:
-        repo: https://github.com/opdev/fips-assessments.git
+        repo: "{{ fips_repo_url | default('https://github.com/opdev/fips-assessments') }}"
+        version: "{{ fips_repo_branch | default('main') }}"
         dest: "{{ fips_repo }}"
+        update: "{{ fips_git_update | default(true) }}"
       when: fips_assessment | default(false)
     - name: Execute operator_install.yml for each openshift_sub_info
       ansible.builtin.include_tasks: operator_install.yml
@@ -70,3 +72,6 @@
       ansible.builtin.file:
         path: "{{ fips_repo }}"
         state: absent
+      when:
+        - fips_assessment | default(false)
+        - fips_git_cleanup | default(false)

--- a/install.yml
+++ b/install.yml
@@ -77,6 +77,14 @@
         operator_timeout: true
 - name: Run FIPS enabled tests
   ansible.builtin.include_tasks: fips_assessment.yml
+  vars:
+    target_namespace: "{{ item in ['OwnNamespace'] | ternary(full_namespace, [full_namespace, 'targetns1'] | join('-')) }}"
+  when: fips_assessment | default(false)
+  register: fips_results
+- name: Push FIPS stats
+  ansible.builtin.set_stats:
+    data:
+      fips: "{{ [fips_results] }}"
   when: fips_assessment | default(false)
 - name: Create stat
   ansible.builtin.set_fact:
@@ -91,6 +99,38 @@
   ansible.builtin.set_stats:
     data:
       operators: "{{ [package] }}"
+- name: Clean up addition namespace - SingleNamespace or MultiNamespace
+  kubernetes.core.k8s:
+    name: "{{ [full_namespace, 'targetns1'] | join('-') }}"
+    api_version: v1
+    kind: Namespace
+    definition:
+      metadata:
+        labels:
+          opdev: opcap
+    state: absent
+    wait: true
+    wait_timeout: 60
+    wait_sleep: 10
+  when:
+    - item in ["SingleNamespace", "MultiNamespace"]
+    - cleanup is defined and cleanup
+- name: Clean up additional namespace - SingleNamespace or MultiNamespace
+  kubernetes.core.k8s:
+    name: "{{ [full_namespace, 'targetns2'] | join('-') }}"
+    api_version: v1
+    kind: Namespace
+    definition:
+      metadata:
+        labels:
+          opdev: opcap
+    state: absent
+    wait: true
+    wait_timeout: 60
+    wait_sleep: 10
+  when:
+    - item in ["MultiNamespace"]
+    - cleanup is defined and cleanup
 - name: Clean up namespace
   kubernetes.core.k8s:
     api_version: v1

--- a/vars.yml.example
+++ b/vars.yml.example
@@ -13,3 +13,10 @@ cleanup: true
 #  1. list only packages that have corresponding tests on packages var
 #  2. uncomment and set fips_assessment to true below
 # fips_assessment: true
+# One can override the fips assessment repo and branch to
+# facilitate testing new fips assessments
+# fips_repo_url: https://github.com/opdev/fips-assessments
+# fips_repo_branch: main
+# fips_git_update: false <--- If you want to use the repo from a directory
+# fips_repo_base_path: /some/base-location <--- Use with the above
+# fips_git_cleanup: false <--- If using the above, you will probably want this false


### PR DESCRIPTION
* Pass the correct namespace for fips assessments
* Clean up the secondary namespaces
* Make the fips assessments repo able to be pulled outside of opcap-ansible for testing

Fixes #32