### PR TITLE
truncate more characters of package name

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -1,10 +1,10 @@
 ---
 - name: Generate full namespace
   ansible.builtin.set_fact:
-    install_namespace: "opcap-{{ namespace }}-{{ item | lower }}"
+    install_namespace: "{{ manifest_data.packageName | sha1 | truncate(8, False, '', 0) }}-{{ item | truncate(1, False, '', 0) | lower }}"
 - name: Generate target namespace
   ansible.builtin.set_fact:
-    target_namespace: "{{ (item not in ['OwnNamespace']) | ternary([install_namespace, 'targetns1'] | join('-'), install_namespace) }}"
+    target_namespace: "{{ (item not in ['OwnNamespace']) | ternary([install_namespace, 'ns1'] | join('-'), install_namespace) }}"
 - name: Create main namespace
   kubernetes.core.k8s:
     name: "{{ install_namespace }}"

--- a/operator_install.yml
+++ b/operator_install.yml
@@ -8,9 +8,6 @@
 - name: Get supported InstallModes
   ansible.builtin.set_fact:
     install_modes: "{{ channel.currentCSVDesc.installModes | selectattr('supported') | map(attribute='type') }}"
-- name: Generate namespace from package name
-  ansible.builtin.set_fact:
-    namespace: "{{ manifest_data.packageName | replace('.', '-') | lower | truncate(40) }}"
 - name: Install Operator with each install type
   ansible.builtin.include_tasks: install.yml
   vars:


### PR DESCRIPTION
When testing package manifest names with long number of characters, i.e. `ansible-automation-platform-operator`, ran into an issue with inability to create kube resources when operators rely on namespace names for naming things like urls for routes.

Also saw some errors due to kube namespace character limitations if testing install modes other than OwnNamespace, i.e. when it appends `singlenamespace-targetns1` to the already long package manifest name.