### PR TITLE
Update requirements.txt with boto3 and botocore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ ansible-builder==3.0.0
 ansible-lint==6.18.0
 ansible-navigator==3.4.2
 ansible-runner==2.3.4
+boto3==1.28.40
+botocore==1.31.40
 kubernetes==27.2.0


### PR DESCRIPTION
3scale uses `amazon.aws.s3_bucket` module which depends on boto3 and botocore