### PR TITLE
Pull FIPS collection into execution environment

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+
 jobs:
   build:
     name: Ansible Lint on PR
@@ -14,8 +16,16 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Add ansible.cfg from secrets
+        run: |
+          echo -n ${ANSIBLE_CFG} | base64 --decode > ansible.cfg
+        shell: bash
+        env:
+          ANSIBLE_CFG: "${{ secrets.ANSIBLE_CFG }}"
+
       - name: Install galaxy colletions
-        run: ansible-galaxy install -r requirements.yml
+        run: ansible-galaxy install -vvvv -r requirements.yml
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint@main
+

--- a/.github/workflows/opcap-ansible-ee-build.yml
+++ b/.github/workflows/opcap-ansible-ee-build.yml
@@ -8,7 +8,6 @@ on:
       - '**/execution-environment.yml'
       - '**/requirements.yml'
       - '**/requirements.txt'
-      - '**/ansible.cfg'
   workflow_dispatch:
   
 jobs:
@@ -18,6 +17,13 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Add ansible.cfg from secrets
+        run: |
+          echo -n ${ANSIBLE_CFG} | base64 --decode > ansible.cfg
+        shell: bash
+        env:
+          ANSIBLE_CFG: "${{ secrets.ANSIBLE_CFG }}"
 
       - name: Install python requirements (ansible-builder)
         run: pip install -r requirements.txt
@@ -48,3 +54,4 @@ jobs:
           registry: quay.io/opdev
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 vars.yaml
 vars.yml
 
+# Do not include ansible.cfg as it could contain secrets
+ansible.cfg
+
 # audits-artifact
 audits-artifact*
 
@@ -32,3 +35,10 @@ ansible-navigator.log
 
 # Ignore local ansible navigator configs
 ansible-navigator.yaml
+
+# Ignore collections from galaxy
+collections/
+
+# Ignore context from ansible-builder
+context/
+

--- a/ansible.cfg.template
+++ b/ansible.cfg.template
@@ -9,10 +9,22 @@
 # the run, so you can still validate what would be output.
 show_custom_stats = true
 
-# This will be necessary until we get the fips_assessment collection going
-roles_path = ./roles:../fips-assessments/roles
-
 # callbacks_enabled = ansible.posix.timer,ansible.posix.profile_tasks,ansible.posix.profile_roles
 
 forks = 20
+
+[galaxy]
+server_list = published, rh-certified, community
+
+[galaxy_server.published]
+url=https://<insert hub url here>/api/galaxy/
+token=<insert token here>
+
+[galaxy_server.rh-certified]
+url=https://<insert hub url here>/api/galaxy/content/rh-certified/
+token=<insert token here>
+
+[galaxy_server.community]
+url=https://<insert hub url here>/api/galaxy/content/community/
+token=<insert token here>
 

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -17,9 +17,11 @@ additional_build_files:
      dest: configs
 
 additional_build_steps:
+  prepend_builder: |
+    RUN pip3 install --upgrade pip setuptools
   prepend_galaxy:
-    - ADD _build/configs/ansible.cfg ~/.ansible.cfg
-  append_final:
-    - RUN cd /usr/local/bin && \
-          curl -O https://mirror.openshift.com/pub/rhacs/assets/4.1.2/bin/linux/roxctl && \
-          chmod +x /usr/local/bin/roxctl
+    - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+  append_final: |
+    RUN cd /usr/local/bin && \
+        curl -O https://mirror.openshift.com/pub/rhacs/assets/4.1.2/bin/linux/roxctl && \
+        chmod +x /usr/local/bin/roxctl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-ansible==8.4.0
 ansible-builder==3.0.0
-ansible-lint==6.19.0
-ansible-navigator==3.4.2
+ansible-lint==6.21.1
+ansible-navigator==3.5.0
 ansible-runner==2.3.4
 boto3==1.28.49
 botocore==1.31.49
-kubernetes==27.2.0
+kubernetes>=28.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,4 @@
 ---
 collections:
+  - name: opdev.fips_assessments
   - name: kubernetes.core
-
-# Once this is publish in the private automation hub, we can use this directly
-#  - name: opdev.fips_assessments

--- a/roles/fips_assessment/meta/main.yml
+++ b/roles/fips_assessment/meta/main.yml
@@ -51,3 +51,7 @@ dependencies: []
 
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.
+  #
+
+collections:
+  - opdev.fips_assessments

--- a/roles/fips_assessment/tasks/main.yml
+++ b/roles/fips_assessment/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Execute fips-assessment role
   ansible.builtin.include_role:
-    name: "{{ package_role }}"
+    name: "opdev.fips_assessments.{{ package_role }}"
   vars:
     install_namespace: "{{ fips_assessment_install_namespace }}"
     target_namespace: "{{ fips_assessment_target_namespace }}"


### PR DESCRIPTION
In order to make a more turnkey solution for running opcap-ansible, this adds the fips-assessment collection to the execution environment.

The GitHub action uses an ansible.cfg from a secret, since it has both the URL for the private automation hub and the token for the hub.

Ansible.cfg is moved to ansible.cfg.template and added to .gitignore to hopefully prevent tokens from leaking.

Fixes #98