### PR TITLE
Process package manifests if no packages given

### DIFF
--- a/audits.yml
+++ b/audits.yml
@@ -41,6 +41,10 @@
     - name: Set fact
       ansible.builtin.set_fact:
         cluster_base_url: "{{ cluster_dns.resources[0].spec.baseDomain }}"
+    - name: Build packages list when no packages specified
+      ansible.builtin.include_tasks:
+        file: packages.yml
+      when: packages | default([]) | length == 0
     - name: Build package "inventory"
       ansible.builtin.add_host:
         name: "{{ item.name }}"
@@ -53,10 +57,19 @@
         ansible_connection: local
       loop: "{{ packages }}"
       when: packages | default([]) | length > 0
+    - name: Fail if we have no package list at this point
+      ansible.builtin.fail:
+        msg: No package list available
+      when: packages | default([]) | length == 0
 
 - name: Run assessments
   hosts: packages
   gather_facts: false
+  serial:
+    - 1
+    - 5
+    - "{{ max_batch_size | default(10) }}"
+  max_fail_percentage: 99
   pre_tasks:
     - name: Cluster base url?
       ansible.builtin.debug:

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,36 @@
+---
+- name: Get list of packages
+  kubernetes.core.k8s_info:
+    api_version: "packages.operators.coreos.com/v1"
+    kind: PackageManifest
+    namespace: '{{ catalog_source_namespace | default("openshift-marketplace") }}'
+    label_selectors:
+      - 'catalog = {{ catalog_source | default("certified-operators") }}'
+  no_log: true
+  register: package_manifest_list
+  failed_when: >
+    (package_manifest_list.resources is not defined) or
+    (package_manifest_list.resources | length == 0)
+  when: packages | default([]) | length == 0
+  tags:
+    - inventory
+    - cleanup
+- name: Get subscription data from OpenShift
+  ansible.builtin.set_fact:
+    openshift_sub_info: "{{ package_manifest_list.resources |
+                            map(attribute='status') |
+                            list }}"
+  no_log: true
+  tags:
+    - inventory
+    - cleanup
+- name: Add each to list
+  ansible.builtin.set_fact:
+    packages: >
+      {{ packages | default([]) + [
+        {"name": item.packageName, "catalog_source": item.catalogSource, "catalog_source_namespace": item.catalogSourceNamespace}
+      ] }}
+  loop: "{{ openshift_sub_info }}"
+  tags:
+    - inventory
+    - cleanup

--- a/roles/operator/tasks/install.yml
+++ b/roles/operator/tasks/install.yml
@@ -28,7 +28,11 @@
         api_version: operators.coreos.com/v1alpha1
         kind: ClusterServiceVersion
       register: result
-      until: result.resources[0] is defined and result.resources[0].status.phase == "Succeeded"
+      until:
+        - result.resources[0] is defined
+        - result.resources[0].status is defined
+        - result.resources[0].status.phase is defined
+        - result.resources[0].status.phase == "Succeeded"
       retries: 30
       delay: 10
       failed_when: result.resources is not defined or result.resources | length == 0 or result.resources[0].status.phase != "Succeeded"


### PR DESCRIPTION
This re-implements the old behavior of checking a catalog source for the list of packages if no package list (or an empty one) is given. It defaults to the certified-operators catalog, but can be changed if catalog_source is given as a variable.

It will also default to the 'openshift-marketplace' as the catalog source namespace.

Fixes #102