### PR TITLE
Point requirements.yml directly at git

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -16,14 +16,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Add ansible.cfg from secrets
-        run: |
-          echo -n ${ANSIBLE_CFG} | base64 --decode > ansible.cfg
-        shell: bash
-        env:
-          ANSIBLE_CFG: "${{ secrets.ANSIBLE_CFG }}"
-
-      - name: Install galaxy colletions
+      - name: Install galaxy collections
         run: ansible-galaxy install -vvvv -r requirements.yml
 
       - name: Run ansible-lint

--- a/.github/workflows/opcap-ansible-ee-build.yml
+++ b/.github/workflows/opcap-ansible-ee-build.yml
@@ -18,13 +18,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Add ansible.cfg from secrets
-        run: |
-          echo -n ${ANSIBLE_CFG} | base64 --decode > ansible.cfg
-        shell: bash
-        env:
-          ANSIBLE_CFG: "${{ secrets.ANSIBLE_CFG }}"
-
       - name: Install python requirements (ansible-builder)
         run: pip install -r requirements.txt
 

--- a/ansible.cfg.template
+++ b/ansible.cfg.template
@@ -13,18 +13,3 @@ show_custom_stats = true
 
 forks = 20
 
-[galaxy]
-server_list = published, rh-certified, community
-
-[galaxy_server.published]
-url=https://<insert hub url here>/api/galaxy/
-token=<insert token here>
-
-[galaxy_server.rh-certified]
-url=https://<insert hub url here>/api/galaxy/content/rh-certified/
-token=<insert token here>
-
-[galaxy_server.community]
-url=https://<insert hub url here>/api/galaxy/content/community/
-token=<insert token here>
-

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -12,15 +12,11 @@ dependencies:
   python: requirements.txt
   galaxy: requirements.yml
 
-additional_build_files:
-   - src: ansible.cfg
-     dest: configs
-
 additional_build_steps:
+  prepend_base: |
+    RUN dnf install -y git
   prepend_builder: |
     RUN pip3 install --upgrade pip setuptools
-  prepend_galaxy:
-    - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
   append_final: |
     RUN cd /usr/local/bin && \
         curl -O https://mirror.openshift.com/pub/rhacs/assets/4.1.2/bin/linux/roxctl && \

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,6 @@
 ---
 collections:
-  - name: opdev.fips_assessments
+  - name: https://github.com/opdev/fips-assessments.git
+    type: git
+    version: main
   - name: kubernetes.core


### PR DESCRIPTION
Since secrets cannot be passed in from a forked repo, instead we will use a requirements file that just uses the main branch of the fips assessments repo directly.

Also changes the execution-environment.yml accordingly to account for this change.